### PR TITLE
Add coverage for role assumers before experimenting with using local credentials fromIni

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
 
 local:
 	docker run -p 8000:8000 amazon/dynamodb-local
+
+seed:
+	aws dynamodb create-table \
+		--table-name Music \
+		--attribute-definitions \
+			AttributeName=Artist,AttributeType=S \
+			AttributeName=SongTitle,AttributeType=S \
+		--key-schema \
+			AttributeName=Artist,KeyType=HASH \
+			AttributeName=SongTitle,KeyType=RANGE \
+		--provisioned-throughput \
+			ReadCapacityUnits=10,WriteCapacityUnits=5 \
+		--profile=local

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+local:
+	docker run -p 8000:8000 amazon/dynamodb-local

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Open source GUI for working with AWS DynamoDB.
 
 - [DynamoDB benchworx](#dynamodb-benchworx)
   - [Features](#features)
+  - [Configuration](#configuration)
+    - [Standard Profile](#standard-profile)
+    - [MFA Profile](#mfa-profile)
+    - [Assume Role in another Account](#assume-role-in-another-account)
+    - [Assume Role with MFA](#assume-role-with-mfa)
+    - [Local](#local)
 
 ## Features
 
@@ -18,3 +24,81 @@ Open source GUI for working with AWS DynamoDB.
 - [ ] Edit dynamoDB records as JSON using monaco editor
 - [ ] Query and Scan on Primary, Local Secondary, and Global Secondary indexes
 - [ ] Use the aws-sdk for dynamo to design and test queries inside an authenticated REPL
+
+## Configuration
+
+Configuration is supported via the AWS credentials and config files.
+
+By default all available profiles are show in the profile selection.
+
+Here are some examples:
+
+### Standard Profile
+
+```
+~/.aws/credentials
+[profile-name]
+aws_access_key_id = id
+aws_secret_access_key = secret
+```
+
+### MFA Profile
+
+```
+~/.aws/credentials
+[profile-name]
+aws_access_key_id = id
+aws_secret_access_key = secret
+```
+
+```
+~/.aws/config
+[profile mfa-profile]
+mfa_serial = arn:aws:iam::<aws_account_arn>:mfa/<username>
+source_profile = profile-name
+```
+
+### Assume Role in another Account
+
+```
+~/.aws/credentials
+[profile-name]
+aws_access_key_id = id
+aws_secret_access_key = secret
+```
+
+```
+~/.aws/config
+[profile assumed-role]
+role_arn = arn:aws:iam::<aws_target_account_arn>:role/<RoleName>
+source_profile = profile-name
+```
+
+### Assume Role with MFA
+
+```
+~/.aws/credentials
+[profile-name]
+aws_access_key_id = id
+aws_secret_access_key = secret
+```
+
+```
+~/.aws/config
+[profile mfa-assumed-role]
+mfa_serial = arn:aws:iam::<aws_account_arn>:mfa/<username>
+role_arn = arn:aws:iam::<aws_target_account_arn>:role/<RoleName>
+source_profile = profile-name
+```
+
+### Local
+
+Setup a local dynamoDB agent on a specified port.
+
+```
+~/.aws/config
+[profile local]
+region = local
+output = json
+endpoint=http://localhost:8000
+```

--- a/src/pages/workbench/settings/query-planner.tsx
+++ b/src/pages/workbench/settings/query-planner.tsx
@@ -1,4 +1,9 @@
-import React, { ReactElement, useContext, useState } from "react";
+import React, {
+  ReactElement,
+  SyntheticEvent,
+  useContext,
+  useState,
+} from "react";
 import {
   Button,
   InputLabel,
@@ -41,7 +46,8 @@ export const QueryPlanner = (): ReactElement => {
     setIndexName(String(e.target.value));
   };
 
-  const getResults = async () => {
+  const getResults = async (e: SyntheticEvent) => {
+    e.preventDefault();
     const options: ScanCommandInput = {
       TableName: table?.Table?.TableName,
     };
@@ -59,124 +65,122 @@ export const QueryPlanner = (): ReactElement => {
   };
 
   return (
-    <Box display="flex" alignItems="flex-start" flexDirection="column" p={1}>
-      <FormControl
-        data-test="toggle-operation"
-        variant="outlined"
-        className={classes.formControl}
-        margin="dense"
-      >
-        <ToggleButtonGroup
-          size="small"
-          value={operation}
-          exclusive
-          onChange={handleOperation}
-          aria-label="dynamodb operation"
+    <form onSubmit={getResults}>
+      <Box display="flex" alignItems="flex-start" flexDirection="column" p={1}>
+        <FormControl
+          data-test="toggle-operation"
+          variant="outlined"
+          className={classes.formControl}
+          margin="dense"
         >
-          <ToggleButton value="scan" aria-label="scan dynamodb">
-            Scan
-          </ToggleButton>
-          <ToggleButton value="query" aria-label="query dynamodb">
-            Query
-          </ToggleButton>
-        </ToggleButtonGroup>
-      </FormControl>
-      <FormControl
-        data-test="select-profile"
-        variant="outlined"
-        className={classes.formControl}
-        margin="dense"
-      >
-        <InputLabel htmlFor="select" shrink>
-          Table or Index
-        </InputLabel>
-        <NativeSelect
-          id="select"
-          margin="dense"
+          <ToggleButtonGroup
+            size="small"
+            value={operation}
+            exclusive
+            onChange={handleOperation}
+            aria-label="dynamodb operation"
+          >
+            <ToggleButton value="scan" aria-label="scan dynamodb">
+              Scan
+            </ToggleButton>
+            <ToggleButton value="query" aria-label="query dynamodb">
+              Query
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </FormControl>
+        <FormControl
+          data-test="select-profile"
           variant="outlined"
-          value={indexName}
-          onChange={handleTableSelection}
+          className={classes.formControl}
+          margin="dense"
         >
-          {table && <option value={null}>{table.Table.TableName}</option>}
-          {table && table.Table.LocalSecondaryIndexes && (
-            <optgroup label="Local Secondary Indexes">
-              {table.Table.LocalSecondaryIndexes.map((lsi) => (
-                <option value={lsi.IndexName} key={lsi.IndexName}>
-                  {lsi.IndexName}
-                </option>
-              ))}
-            </optgroup>
-          )}
-          {table && table.Table.GlobalSecondaryIndexes && (
-            <optgroup label="Global Secondary Indexes">
-              {table.Table.GlobalSecondaryIndexes.map((gsi) => (
-                <option value={gsi.IndexName} key={gsi.IndexName}>
-                  {gsi.IndexName}
-                </option>
-              ))}
-            </optgroup>
-          )}
-        </NativeSelect>
-      </FormControl>
-      <FormControl
-        data-test="enter-pk"
-        variant="outlined"
-        className={classes.formControl}
-        margin="dense"
-      >
-        <TextField
-          id="text-pk"
-          label="(Primary Key)"
+          <InputLabel htmlFor="select" shrink>
+            Table or Index
+          </InputLabel>
+          <NativeSelect
+            id="select"
+            margin="dense"
+            variant="outlined"
+            value={indexName}
+            onChange={handleTableSelection}
+          >
+            {table && <option value={null}>{table.Table.TableName}</option>}
+            {table && table.Table.LocalSecondaryIndexes && (
+              <optgroup label="Local Secondary Indexes">
+                {table.Table.LocalSecondaryIndexes.map((lsi) => (
+                  <option value={lsi.IndexName} key={lsi.IndexName}>
+                    {lsi.IndexName}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {table && table.Table.GlobalSecondaryIndexes && (
+              <optgroup label="Global Secondary Indexes">
+                {table.Table.GlobalSecondaryIndexes.map((gsi) => (
+                  <option value={gsi.IndexName} key={gsi.IndexName}>
+                    {gsi.IndexName}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </NativeSelect>
+        </FormControl>
+        <FormControl
+          data-test="enter-pk"
           variant="outlined"
+          className={classes.formControl}
           margin="dense"
-        />
-      </FormControl>
-      <FormControl
-        data-test="enter-sk"
-        variant="outlined"
-        className={classes.formControl}
-        margin="dense"
-      >
-        <TextField
-          id="text-sk"
-          label="(Sort Key)"
-          variant="outlined"
-          margin="dense"
-        />
-      </FormControl>
-      <FormControl
-        data-test="number-limit"
-        variant="outlined"
-        className={classes.formControl}
-        margin="dense"
-      >
-        <TextField
-          id="number-limit"
-          value={limit}
-          onChange={(e) => setLimit(parseInt(e.target.value))}
-          InputLabelProps={{ shrink: true }}
-          InputProps={{ inputProps: { min: 0, max: 100 } }}
-          inputMode="numeric"
-          type="number"
-          label="Item Limit"
-          variant="outlined"
-          margin="dense"
-        />
-      </FormControl>
-      <FormControl
-        data-test="button-execute"
-        variant="outlined"
-        className={classes.formControl}
-        margin="dense"
-      >
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => getResults()}
         >
-          Execute
-        </Button>
-      </FormControl>
-    </Box>
+          <TextField
+            id="text-pk"
+            label="(Primary Key)"
+            variant="outlined"
+            margin="dense"
+          />
+        </FormControl>
+        <FormControl
+          data-test="enter-sk"
+          variant="outlined"
+          className={classes.formControl}
+          margin="dense"
+        >
+          <TextField
+            id="text-sk"
+            label="(Sort Key)"
+            variant="outlined"
+            margin="dense"
+          />
+        </FormControl>
+        <FormControl
+          data-test="number-limit"
+          variant="outlined"
+          className={classes.formControl}
+          margin="dense"
+        >
+          <TextField
+            id="number-limit"
+            value={limit}
+            onChange={(e) => setLimit(parseInt(e.target.value))}
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ inputProps: { min: 0, max: 100 } }}
+            inputMode="numeric"
+            type="number"
+            label="Item Limit"
+            variant="outlined"
+            margin="dense"
+          />
+        </FormControl>
+        <FormControl
+          data-test="button-execute"
+          variant="outlined"
+          className={classes.formControl}
+          margin="dense"
+        >
+          <Button variant="contained" color="primary" type="submit">
+            Execute
+          </Button>
+        </FormControl>
+      </Box>
+    </form>
   );
 };

--- a/src/utils/aws/accounts/__snapshots__/config.test.ts.snap
+++ b/src/utils/aws/accounts/__snapshots__/config.test.ts.snap
@@ -26,5 +26,12 @@ Array [
     "profile": "mfaRoleAssume",
     "region": "eu-west-1",
   },
+  Object {
+    "assumeRole": false,
+    "endpoint": "http://localhost:1234",
+    "mfa": false,
+    "profile": "local",
+    "region": "local",
+  },
 ]
 `;

--- a/src/utils/aws/accounts/config.test.ts
+++ b/src/utils/aws/accounts/config.test.ts
@@ -1,40 +1,43 @@
 import { listAwsConfig } from "./config";
 
+jest.spyOn(global.console, "info");
 jest.mock("@aws-sdk/shared-ini-file-loader", () => ({
   loadSharedConfigFiles: (): Promise<unknown> => {
-    return new Promise((resolve, _) => {
-      resolve({
-        configFile: {
-          simpleProfile: {
-            region: "us-east-1",
-          },
-          default: {
-            region: "eu-west-2",
-            output: "json",
-          },
-          mfaRoleAssume: {
-            mfa_serial: "arn:aws:iam::1111111111111:mfa/user.name",
-            role_arn: "arn:aws:iam::2222222222:role/userRoleTOAssume",
-            source_profile: "default",
-            region: "eu-west-1",
-            output: "json",
-          },
+    return Promise.resolve({
+      configFile: {
+        simpleProfile: {
+          region: "us-east-1",
         },
-        credentialsFile: {
-          simpleProfile: {
-            aws_access_key_id: "access-1",
-            aws_secret_access_key: "key-2",
-          },
-          cgu: {
-            aws_access_key_id: "access-2",
-            aws_secret_access_key: "key-2",
-          },
-          default: {
-            aws_access_key_id: "access-3",
-            aws_secret_access_key: "key-3",
-          },
+        default: {
+          region: "eu-west-2",
+          output: "json",
         },
-      });
+        mfaRoleAssume: {
+          mfa_serial: "arn:aws:iam::1111111111111:mfa/user.name",
+          role_arn: "arn:aws:iam::2222222222:role/userRoleTOAssume",
+          source_profile: "default",
+          region: "eu-west-1",
+          output: "json",
+        },
+        local: {
+          region: "local",
+          endpoint: "http://localhost:1234",
+        },
+      },
+      credentialsFile: {
+        simpleProfile: {
+          aws_access_key_id: "access-1",
+          aws_secret_access_key: "key-2",
+        },
+        cgu: {
+          aws_access_key_id: "access-2",
+          aws_secret_access_key: "key-2",
+        },
+        default: {
+          aws_access_key_id: "access-3",
+          aws_secret_access_key: "key-3",
+        },
+      },
     });
   },
 }));
@@ -45,21 +48,28 @@ describe("listAwsConfig", () => {
 
     expect(results.data).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           profile: "default",
           mfa: false,
           assumeRole: false,
           region: "eu-west-2",
-        },
-        {
+        }),
+        expect.objectContaining({
           profile: "mfaRoleAssume",
           mfa: true,
           assumeRole: true,
           region: "eu-west-1",
-        },
+        }),
+        expect.objectContaining({
+          profile: "local",
+          mfa: false,
+          assumeRole: false,
+          region: "local",
+          endpoint: "http://localhost:1234",
+        }),
       ])
     );
-    expect(results.data.length).toEqual(4);
+    expect(results.data.length).toEqual(5);
     expect(results.data).toMatchSnapshot();
   });
 });

--- a/src/utils/aws/constants/index.ts
+++ b/src/utils/aws/constants/index.ts
@@ -1,4 +1,5 @@
 export const regions = [
+  "local",
   "af-south-1",
   "ap-east-1",
   "ap-northeast-1",

--- a/src/utils/aws/credentials/index.test.ts
+++ b/src/utils/aws/credentials/index.test.ts
@@ -1,5 +1,46 @@
-describe("credentials", () => {
-  it("caches credentials for the session duration", () => {
-    expect(true).toBe(true);
+import { mocked } from "ts-jest/utils";
+import { authenticator, fetchCredentials } from "./index";
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+
+jest.mock("@aws-sdk/credential-provider-ini");
+const mockFromIni = mocked(fromIni);
+
+const credentialFixture = { accessKeyId: "test", secretAccessKey: "secret" };
+
+describe("fetchCredentials", () => {
+  it("caches credentials for the session duration", async () => {
+    mockFromIni.mockReturnValue(() => Promise.resolve(credentialFixture));
+
+    const result = await fetchCredentials("profile-name");
+    await fetchCredentials("profile-name");
+
+    expect(result).toEqual(credentialFixture);
+    expect(mockFromIni).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("authenticator", () => {
+  it("returns authenticated profiles", async () => {
+    mockFromIni.mockReturnValue(() => Promise.resolve(credentialFixture));
+
+    const result = await authenticator({
+      profile: "profile-name",
+      mfaCode: "",
+    });
+
+    expect(result.type).toEqual("success");
+    expect(result.message).toEqual(`Authenticated for profile-name`);
+  });
+
+  it("handles errors by passing back failure messages", async () => {
+    mockFromIni.mockReturnValue(() => Promise.reject("Serious error!!"));
+
+    const result = await authenticator({
+      profile: "profile-name",
+      mfaCode: "",
+    });
+
+    expect(result.type).toEqual("error");
+    expect(result.message).toEqual(`Failed to authenticate for profile-name`);
   });
 });

--- a/src/utils/aws/credentials/index.ts
+++ b/src/utils/aws/credentials/index.ts
@@ -1,5 +1,4 @@
 import { fromIni } from "@aws-sdk/credential-provider-ini";
-
 import { roleAssumer } from "@src/utils/aws/credentials/role-assumer";
 import { Credentials } from "@aws-sdk/types";
 import { PreloaderResponse } from "@src/preload";

--- a/src/utils/aws/credentials/role-assumer.test.ts
+++ b/src/utils/aws/credentials/role-assumer.test.ts
@@ -1,0 +1,46 @@
+import { roleAssumer } from "./role-assumer";
+
+const credentialFixture = {
+  Expiration: new Date(2020, 4, 5, 9, 30, 0),
+  AccessKeyId: "temporary-key",
+  SecretAccessKey: "temporary-secret",
+  SessionToken: "role-session",
+};
+
+jest.mock("@aws-sdk/client-sts", () => {
+  return {
+    STSClient: jest.fn().mockImplementation(() => {
+      return {
+        send: () =>
+          Promise.resolve({
+            Credentials: { ...credentialFixture },
+          }),
+      };
+    }),
+    AssumeRoleCommand: jest.fn().mockImplementation(() => {
+      return {};
+    }),
+  };
+});
+
+describe("roleAssumer", () => {
+  it("returns the temporary credentials from the assumed role", async () => {
+    const credentials = await roleAssumer(
+      {
+        accessKeyId: "test",
+        secretAccessKey: "secret",
+      },
+      {
+        RoleArn: "string arn",
+        RoleSessionName: "super-session",
+      }
+    );
+
+    expect(credentials).toEqual({
+      accessKeyId: "temporary-key",
+      expiration: new Date(2020, 4, 5, 9, 30, 0),
+      secretAccessKey: "temporary-secret",
+      sessionToken: "role-session",
+    });
+  });
+});

--- a/src/utils/aws/credentials/role-assumer.ts
+++ b/src/utils/aws/credentials/role-assumer.ts
@@ -2,6 +2,7 @@ import { STSClient, AssumeRoleCommand } from "@aws-sdk/client-sts";
 import { Credentials } from "@aws-sdk/types";
 import { AssumeRoleParams } from "@aws-sdk/credential-provider-ini";
 
+// Assume a role using the source credentials provided
 export const roleAssumer = async (
   sourceCredentials: Credentials,
   params: AssumeRoleParams
@@ -15,7 +16,7 @@ export const roleAssumer = async (
   const response = await client.send(command);
 
   return {
-    ...response.Credentials,
+    expiration: response.Credentials.Expiration,
     accessKeyId: response.Credentials.AccessKeyId,
     secretAccessKey: response.Credentials.SecretAccessKey,
     sessionToken: response.Credentials.SessionToken,

--- a/src/utils/aws/dynamo/queries.test.ts
+++ b/src/utils/aws/dynamo/queries.test.ts
@@ -6,12 +6,17 @@ import {
   ListTablesCommandOutput,
 } from "@aws-sdk/client-dynamodb";
 import { fetchCredentials } from "@src/utils/aws/credentials";
+import { listAwsConfig } from "@src/utils/aws/accounts/config";
 import { describeTableResponse } from "@fixtures/index";
 import { PreloaderResponse } from "@src/preload";
 
 jest.spyOn(global.console, "info");
+
 jest.mock("@src/utils/aws/credentials");
 const mockedFetchCredentials = mocked(fetchCredentials);
+
+jest.mock("@src/utils/aws/accounts/config");
+const mockedListAwsConfig = mocked(listAwsConfig);
 
 describe("Queries", () => {
   beforeEach(() => {
@@ -21,6 +26,15 @@ describe("Queries", () => {
     mockedFetchCredentials.mockResolvedValueOnce({
       accessKeyId: "test",
       secretAccessKey: "secret",
+    });
+
+    mockedListAwsConfig.mockResolvedValueOnce({
+      type: "success",
+      data: [
+        { profile: "cgu", mfa: false, assumeRole: false, region: "eu-west-1" },
+      ],
+      message: null,
+      details: null,
     });
   });
 

--- a/src/utils/aws/dynamo/queries.ts
+++ b/src/utils/aws/dynamo/queries.ts
@@ -18,7 +18,7 @@ import { fetchCredentials } from "@src/utils/aws/credentials";
 
 const clientConstructor = async (profile: string, region: string) => {
   const credentials = await fetchCredentials(profile);
-
+  console.info({ credentials });
   const client = new DynamoDBClient({
     region,
     credentials,

--- a/src/utils/aws/dynamo/queries.ts
+++ b/src/utils/aws/dynamo/queries.ts
@@ -18,7 +18,7 @@ import { fetchCredentials } from "@src/utils/aws/credentials";
 
 const clientConstructor = async (profile: string, region: string) => {
   const credentials = await fetchCredentials(profile);
-  console.info({ credentials });
+
   const client = new DynamoDBClient({
     region,
     credentials,


### PR DESCRIPTION
This initial PR adds support for local dynamo DB.

Local will be a nice feature to have, on the roadmap, replicating a table to local so that you can test out transactions, puts, and conditionals will be an awesome feature to enable people to design real-world complex queries.

closes: #36